### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ With more and more defensive OS configuration defaults, getting multicast to run
 * firewall defaults
 * disabled at network adapter level
 * traffic shaping (switch): limited bandwidth for multicast traffic
-* complex network setups with slow network segments attached might backpressure multicast traffic accross the whole network. E.g. an attached 100MBit or wireless lan segment might cause multicast traffic in the 1GBit lan to slow down to wireless network speed.
+* complex network setups with slow network segments attached might backpressure multicast traffic across the whole network. E.g. an attached 100MBit or wireless lan segment might cause multicast traffic in the 1GBit lan to slow down to wireless network speed.
 * IGMP behaviour, buggy IGMP implementations (first message not correctly routed, ..).
 
 ethtool, tcpdump, and netstat are your diagnostic helpers ..


### PR DESCRIPTION
@RuedigerMoeller, I've corrected a typographical error in the documentation of the [fast-cast](https://github.com/RuedigerMoeller/fast-cast) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
